### PR TITLE
performance improvements when copying or streaming new files

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Use `FileSystemOcflStorage.builder()` to create and configure an
 
 * **repositoryRoot**: Required, path to the OCFL storage root
   directory.
+* **verifyInventoryDigest**: Whether to verify inventory digests on
+  read. Default: `true`.
 
 **Example**
 
@@ -227,6 +229,8 @@ Use `CloudOcflStorage.builder()` to create and configure an
 
 * **cloudClient**: Required, sets the `CloudClient` implementation to
   use. For Amazon S3, use `OcflS3Client.builder()`.
+* **verifyInventoryDigest**: Whether to verify inventory digests on
+  read. Default: `true`.
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ following extensions are implemented:
 creating new OCFL objects: OCFL version, digest algorithm, version
 zero-padding width, and content directory. The defaults are `1.0`,
 `sha512`, `0`, and `content`.
+* **verifyStaging**: Determines whether the contents of staged
+  versions should be verified immediately prior to installing them.
+  This is enabled by default, but can be safely disabled if you are
+  concerned with performance on slow filesystems.
 * **prettyPrintJson**: Enables pretty print JSON in newly written
  inventory files. By default, pretty printing is disabled to reduce
  inventory file size.
@@ -161,11 +165,6 @@ Use `FileSystemOcflStorage.builder()` to create and configure an
 
 * **repositoryRoot**: Required, path to the OCFL storage root
   directory.
-* **checkNewVersionFixity**: Optional, instructs the client to check
-the fixity of every file in new versions once the version is at rest.
-By default, this is disabled and it is unlikely to be worthwhile if
-the work directory and OCFL storage root are on the same mount, as
-recommended.
 
 **Example**
 

--- a/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/OcflConstants.java
+++ b/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/OcflConstants.java
@@ -45,7 +45,7 @@ public final class OcflConstants {
     public static final String EXT_CONFIG_JSON = "config.json";
     public static final String INIT_EXT = "init";
 
-    public static final String OBJECT_NAMASTE_PREFIX = "0=ocfl_object";
+    public static final String OBJECT_NAMASTE_PREFIX = "0=ocfl_object_";
     public static final String OBJECT_NAMASTE_1_0 = "0=" + OcflVersion.OCFL_1_0.getOcflObjectVersion();
 
     public static final String DEFAULT_INITIAL_VERSION_ID = "v1";
@@ -61,5 +61,9 @@ public final class OcflConstants {
     public static final String MUTABLE_HEAD_REVISIONS_PATH = MUTABLE_HEAD_EXT_PATH + "/revisions";
 
     public static final String DIGEST_ALGORITHMS_EXT_NAME = "0001-digest-algorithms";
+
+    public static final DigestAlgorithm[] VALID_INVENTORY_ALGORITHMS = new DigestAlgorithm[]{
+            DigestAlgorithm.sha256, DigestAlgorithm.sha512
+    };
 
 }

--- a/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/exception/OcflNoSuchFileException.java
+++ b/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/exception/OcflNoSuchFileException.java
@@ -25,7 +25,6 @@
 package edu.wisc.library.ocfl.api.exception;
 
 import java.io.IOException;
-import java.nio.file.NoSuchFileException;
 
 /**
  * This exception is a wrapper around NoSuchFileException and FileNotFoundException

--- a/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/exception/OcflNoSuchFileException.java
+++ b/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/exception/OcflNoSuchFileException.java
@@ -24,38 +24,23 @@
 
 package edu.wisc.library.ocfl.api.exception;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 
 /**
- * This exception is a wrapper around an IOException
+ * This exception is a wrapper around NoSuchFileException and FileNotFoundException
  */
-public class OcflIOException extends OcflJavaException {
+public class OcflNoSuchFileException extends OcflIOException {
 
     private IOException cause;
     private boolean hasMessage = false;
 
-    /**
-     * Wraps an IO exception in the appropriate wrapper class. For example, NoSuchFileException to OcflNoSuchFileException.
-     *
-     * @param e the base exception
-     * @return wrapped exception
-     */
-    public static OcflIOException from(IOException e) {
-        if (e instanceof NoSuchFileException || e instanceof FileNotFoundException) {
-            return new OcflNoSuchFileException(e);
-        }
-
-        return new OcflIOException(e);
-    }
-
-    public OcflIOException(IOException cause) {
+    public OcflNoSuchFileException(IOException cause) {
         super(cause);
         this.cause = cause;
     }
 
-    public OcflIOException(String message, IOException cause) {
+    public OcflNoSuchFileException(String message, IOException cause) {
         super(message, cause);
         this.cause = cause;
         this.hasMessage = true;

--- a/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/model/OcflVersion.java
+++ b/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/model/OcflVersion.java
@@ -27,6 +27,7 @@ package edu.wisc.library.ocfl.api.model;
 import edu.wisc.library.ocfl.api.exception.OcflJavaException;
 
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * Represents a version of the OCFL spec.
@@ -82,13 +83,69 @@ public enum OcflVersion {
      * @return OCFL version
      */
     public static OcflVersion fromOcflVersionString(String ocflVersionString) {
+        var trimmed = ocflVersionString.trim();
         for (var version : values()) {
-            if (version.getOcflVersion().equals(ocflVersionString)) {
+            if (version.getOcflVersion().equals(trimmed)) {
                 return version;
             }
         }
         throw new OcflJavaException(String.format("Unable to map string '%s' to a known OCFL version. Known versions: %s",
                 ocflVersionString, Arrays.asList(values())));
+    }
+
+    /**
+     * Returns an OCFL version based on the OCFL version string specified in the Namaste file in an OCFL object.
+     *
+     * @param ocflObjectVersionString the version string from the object Namaste file
+     * @return OCFL version
+     */
+    public static OcflVersion fromOcflObjectVersionString(String ocflObjectVersionString) {
+        var trimmed = ocflObjectVersionString.trim();
+        for (var version : values()) {
+            if (version.getOcflObjectVersion().equals(trimmed)) {
+                return version;
+            }
+        }
+        throw new OcflJavaException(String.format("Unable to map string '%s' to a known OCFL object version. Known versions: %s",
+                ocflObjectVersionString, Arrays.stream(values())
+                        .map(OcflVersion::getOcflObjectVersion)
+                        .collect(Collectors.toList())));
+    }
+
+    /**
+     * Returns an OCFL version based on the name of an OCFL storage root Namaste file
+     *
+     * @param ocflVersionFilename Namaste file name
+     * @return OCFL version
+     */
+    public static OcflVersion fromOcflVersionFilename(String ocflVersionFilename) {
+        var versionPart = ocflVersionFilename.substring(2);
+        for (var version : values()) {
+            if (version.getOcflVersion().equals(versionPart)) {
+                return version;
+            }
+        }
+        throw new OcflJavaException(String.format("Unable to map string '%s' to a known OCFL version. Known versions: %s",
+                versionPart, Arrays.asList(values())));
+    }
+
+    /**
+     * Returns an OCFL version based on the name of an OCFL object Namaste file
+     *
+     * @param ocflObjectVersionFilename Namaste file name
+     * @return OCFL version
+     */
+    public static OcflVersion fromOcflObjectVersionFilename(String ocflObjectVersionFilename) {
+        var versionPart = ocflObjectVersionFilename.substring(2);
+        for (var version : values()) {
+            if (version.getOcflObjectVersion().equals(versionPart)) {
+                return version;
+            }
+        }
+        throw new OcflJavaException(String.format("Unable to map string '%s' to a known OCFL object version. Known versions: %s",
+                versionPart, Arrays.stream(values())
+                        .map(OcflVersion::getOcflObjectVersion)
+                        .collect(Collectors.toList())));
     }
 
 }

--- a/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/model/VersionInfo.java
+++ b/ocfl-java-api/src/main/java/edu/wisc/library/ocfl/api/model/VersionInfo.java
@@ -24,8 +24,6 @@
 
 package edu.wisc.library.ocfl.api.model;
 
-import edu.wisc.library.ocfl.api.util.Enforce;
-
 import java.time.OffsetDateTime;
 import java.util.Objects;
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultMutableOcflRepository.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultMutableOcflRepository.java
@@ -68,15 +68,17 @@ public class DefaultMutableOcflRepository extends DefaultOcflRepository implemen
      * @param logicalPathMapper logical path mapper
      * @param contentPathConstraintProcessor content path constraint processor
      * @param config ocfl defaults configuration
+     * @param verifyStaging true if the contents of a stage version should be double-checked
      */
     public DefaultMutableOcflRepository(OcflStorage storage, Path workDir,
                                         ObjectLock objectLock,
                                         InventoryMapper inventoryMapper,
                                         LogicalPathMapper logicalPathMapper,
                                         ContentPathConstraintProcessor contentPathConstraintProcessor,
-                                        OcflConfig config) {
+                                        OcflConfig config,
+                                        boolean verifyStaging) {
         super(storage, workDir, objectLock, inventoryMapper,
-                logicalPathMapper, contentPathConstraintProcessor, config);
+                logicalPathMapper, contentPathConstraintProcessor, config, verifyStaging);
     }
 
     /**

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/OcflRepositoryBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/OcflRepositoryBuilder.java
@@ -77,6 +77,7 @@ public class OcflRepositoryBuilder {
     private OcflConfig config;
     private OcflExtensionConfig defaultLayoutConfig;
     private Path workDir;
+    private boolean verifyStaging;
 
     private ObjectLock objectLock;
     private Cache<String, Inventory> inventoryCache;
@@ -104,6 +105,7 @@ public class OcflRepositoryBuilder {
         contentPathConstraintProcessor = ContentPathConstraints.none();
         unsupportedBehavior = UnsupportedExtensionBehavior.FAIL;
         ignoreUnsupportedExtensions = Collections.emptySet();
+        verifyStaging = true;
     }
 
     /**
@@ -370,6 +372,22 @@ public class OcflRepositoryBuilder {
     }
 
     /**
+     * Configures whether to verify the contents of a staged version before it is moved into the OCFL object. This
+     * verification includes iterating over all of the files in the version and ensuring they match the expectations
+     * in the inventory.
+     *
+     * This verification is enabled by default out of conservatism. It is unlikely that there will ever be a problem
+     * for it to uncover, and it can be safely disabled if there are concerns about performance on slower filesystems.
+     *
+     * @param verifyStaging true if the contents of a stage version should be double-checked
+     * @return builder
+     */
+    public OcflRepositoryBuilder verifyStaging(boolean verifyStaging) {
+        this.verifyStaging = verifyStaging;
+        return this;
+    }
+
+    /**
      * Constructs an OCFL repository. Brand new repositories are initialized.
      *
      * @return OcflRepository
@@ -412,7 +430,7 @@ public class OcflRepositoryBuilder {
         return clazz.cast(new DefaultOcflRepository(wrappedStorage, workDir,
                 objectLock, inventoryMapper,
                 logicalPathMapper, contentPathConstraintProcessor,
-                config));
+                config, verifyStaging));
     }
 
     private OcflStorage cache(OcflStorage storage) {

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/OcflRepositoryBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/OcflRepositoryBuilder.java
@@ -424,7 +424,7 @@ public class OcflRepositoryBuilder {
             return clazz.cast(new DefaultMutableOcflRepository(wrappedStorage, workDir,
                     objectLock, inventoryMapper,
                     logicalPathMapper, contentPathConstraintProcessor,
-                    config));
+                    config, verifyStaging));
         }
 
         return clazz.cast(new DefaultOcflRepository(wrappedStorage, workDir,

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/InventoryMapper.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/InventoryMapper.java
@@ -24,18 +24,25 @@
 
 package edu.wisc.library.ocfl.core.inventory;
 
+import at.favre.lib.bytes.Bytes;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.wisc.library.ocfl.api.exception.CorruptObjectException;
 import edu.wisc.library.ocfl.api.exception.OcflIOException;
+import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.api.util.Enforce;
 import edu.wisc.library.ocfl.core.model.Inventory;
 import edu.wisc.library.ocfl.core.model.RevisionNum;
 import edu.wisc.library.ocfl.core.util.ObjectMappers;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.security.DigestInputStream;
 
 /**
  * Wrapper around Jackson's ObjectMapper for serializing and deserializing Inventories. The ObjectMapper setup is a finicky
@@ -90,59 +97,110 @@ public class InventoryMapper {
         }
     }
 
-    public Inventory read(String objectRootPath, String digest, Path path) {
-        return readInternal(false, null, objectRootPath, digest, path);
+    public Inventory read(String objectRootPath, DigestAlgorithm digestAlgorithm, Path path) {
+        return readInternal(false, null, objectRootPath, digestAlgorithm, path);
     }
 
-    public Inventory read(String objectRootPath, String digest, InputStream inputStream) {
-        return readInternal(false, null, objectRootPath, digest, inputStream);
+    public Inventory read(String objectRootPath, DigestAlgorithm digestAlgorithm, InputStream inputStream) {
+        return readInternal(false, null, objectRootPath, digestAlgorithm, inputStream);
     }
 
-    public Inventory readMutableHead(String objectRootPath, String digest, RevisionNum revisionNum, Path path) {
-        return readInternal(true, revisionNum, objectRootPath, digest, path);
+    public Inventory readMutableHead(String objectRootPath, RevisionNum revisionNum, DigestAlgorithm digestAlgorithm, Path path) {
+        return readInternal(true, revisionNum, objectRootPath, digestAlgorithm, path);
     }
 
-    public Inventory readMutableHead(String objectRootPath, String digest, RevisionNum revisionNum, InputStream inputStream) {
-        return readInternal(true, revisionNum, objectRootPath, digest, inputStream);
+    public Inventory readMutableHead(String objectRootPath, RevisionNum revisionNum, DigestAlgorithm digestAlgorithm, InputStream inputStream) {
+        return readInternal(true, revisionNum, objectRootPath, digestAlgorithm, inputStream);
+    }
+
+    public Inventory readNoDigest(String objectRootPath, Path path) {
+        return readInternal(false, null, objectRootPath, null, path);
+    }
+
+    public Inventory readNoDigest(String objectRootPath, InputStream inputStream) {
+        return readInternal(false, null, objectRootPath, null, inputStream);
+    }
+
+    public Inventory readMutableHeadNoDigest(String objectRootPath, RevisionNum revisionNum, Path path) {
+        return readInternal(true, revisionNum, objectRootPath, null, path);
+    }
+
+    public Inventory readMutableHeadNoDigest(String objectRootPath, RevisionNum revisionNum, InputStream inputStream) {
+        return readInternal(true, revisionNum, objectRootPath, null, inputStream);
     }
 
     private Inventory readInternal(boolean mutableHead,
                                    RevisionNum revisionNum,
                                    String objectRootPath,
-                                   String digest,
+                                   DigestAlgorithm digestAlgorithm,
                                    Path path) {
-        Enforce.notBlank(digest, "digest cannot be blank");
+        return readInternal(mutableHead, revisionNum, objectRootPath, readBytes(path, digestAlgorithm));
+    }
+
+    private Inventory readInternal(boolean mutableHead,
+                                   RevisionNum revisionNum,
+                                   String objectRootPath,
+                                   DigestAlgorithm digestAlgorithm,
+                                   InputStream inputStream) {
+        return readInternal(mutableHead, revisionNum, objectRootPath, readBytes(inputStream, digestAlgorithm));
+    }
+
+    private Inventory readInternal(boolean mutableHead,
+                                   RevisionNum revisionNum,
+                                   String objectRootPath,
+                                   ReadResult readResult) {
         try {
             return objectMapper.reader(
                     new InjectableValues.Std()
                             .addValue("revisionNum", revisionNum)
                             .addValue("mutableHead", mutableHead)
                             .addValue("objectRootPath", objectRootPath)
-                            .addValue("currentDigest", digest))
+                            .addValue("inventoryDigest", readResult.digest))
                     .forType(Inventory.class)
-                    .readValue(path.toFile());
+                    .readValue(readResult.bytes);
         } catch (IOException e) {
             throw new OcflIOException(e);
         }
     }
 
-    private Inventory readInternal(boolean mutableHead,
-                                   RevisionNum revisionNum,
-                                   String objectRootPath,
-                                   String digest,
-                                   InputStream inputStream) {
-        Enforce.notBlank(digest, "digest cannot be blank");
-        try {
-            return objectMapper.reader(
-                    new InjectableValues.Std()
-                            .addValue("revisionNum", revisionNum)
-                            .addValue("mutableHead", mutableHead)
-                            .addValue("objectRootPath", objectRootPath)
-                            .addValue("currentDigest", digest))
-                    .forType(Inventory.class)
-                    .readValue(inputStream);
+    private ReadResult readBytes(Path path, DigestAlgorithm digestAlgorithm) {
+        try (var stream = Files.newInputStream(path)) {
+            return readBytes(stream, digestAlgorithm);
+        } catch (NoSuchFileException e) {
+            throw new CorruptObjectException(String.format("Inventory missing at: %s", path), e);
         } catch (IOException e) {
             throw new OcflIOException(e);
+        }
+    }
+
+    private ReadResult readBytes(InputStream stream, DigestAlgorithm digestAlgorithm) {
+        var bufferedStream = new BufferedInputStream(stream);
+
+        try {
+            byte[] bytes;
+            String digest = null;
+
+            if (digestAlgorithm != null) {
+                var wrapped = new DigestInputStream(bufferedStream, digestAlgorithm.getMessageDigest());
+                bytes = wrapped.readAllBytes();
+                digest = Bytes.wrap(wrapped.getMessageDigest().digest()).encodeHex();
+            } else {
+                bytes = bufferedStream.readAllBytes();
+            }
+
+            return new ReadResult(bytes, digest);
+        } catch (IOException e) {
+            throw new OcflIOException(e);
+        }
+    }
+
+    private static class ReadResult {
+        final byte[] bytes;
+        final String digest;
+
+        public ReadResult(byte[] bytes, String digest) {
+            this.bytes = bytes;
+            this.digest = digest;
         }
     }
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/InventoryUpdater.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/InventoryUpdater.java
@@ -212,6 +212,17 @@ public class InventoryUpdater {
     }
 
     /**
+     * Maps the logical path to a content path and returns the part of the content path that's under the
+     * content directory.
+     *
+     * @param logicalPath the logical path
+     * @return content path part that's under the content directory
+     */
+    public String innerContentPath(String logicalPath) {
+        return pathUnderContentDir(contentPathMapper.fromLogicalPath(logicalPath));
+    }
+
+    /**
      * Adds an entry to the fixity block. An entry is not added if the algorithm is the same as the inventory's algorithm.
      *
      * @param logicalPath the file's logical path

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/model/Inventory.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/model/Inventory.java
@@ -100,7 +100,7 @@ public class Inventory {
 
     // This property is injected
     @JsonIgnore
-    private final String currentDigest;
+    private String inventoryDigest;
 
     /**
      * Creates a stub inventory that is useful when creating new objects. It should NOT be persisted.
@@ -156,7 +156,7 @@ public class Inventory {
      * @param revisionNum current revision number
      * @param objectRootPath object root path
      * @param previousDigest digest of previous inventory
-     * @param currentDigest digest of this inventory
+     * @param inventoryDigest digest of this inventory
      */
     public Inventory(
             String id,
@@ -171,7 +171,7 @@ public class Inventory {
             RevisionNum revisionNum,
             String objectRootPath,
             String previousDigest,
-            String currentDigest) {
+            String inventoryDigest) {
         this.id = Enforce.notBlank(id, "id cannot be blank");
         this.type = Enforce.notNull(type, "type cannot be null");
         this.digestAlgorithm = Enforce.notNull(digestAlgorithm, "digestAlgorithm cannot be null");
@@ -189,7 +189,7 @@ public class Inventory {
         this.revisionNum = revisionNum;
         this.objectRootPath = Enforce.notBlank(objectRootPath, "objectRootPath cannot be blank");
         this.previousDigest = previousDigest;
-        this.currentDigest = currentDigest;
+        this.inventoryDigest = inventoryDigest;
     }
 
     /**
@@ -215,7 +215,7 @@ public class Inventory {
         this.revisionNum = null;
         this.objectRootPath = Enforce.notBlank(objectRootPath, "objectRootPath cannot be null");
         this.previousDigest = null;
-        this.currentDigest = null;
+        this.inventoryDigest = null;
     }
 
     /**
@@ -234,8 +234,8 @@ public class Inventory {
      */
     public InventoryBuilder buildNextVersionFrom() {
         return buildFrom()
-                .previousDigest(getCurrentDigest())
-                .currentDigest(null);
+                .previousDigest(getInventoryDigest())
+                .inventoryDigest(null);
     }
 
     private static Map<DigestAlgorithm, PathBiMap> createFixityBiMap(Map<DigestAlgorithm, Map<String, Set<String>>> fixity) {
@@ -514,13 +514,13 @@ public class Inventory {
     }
 
     /**
-     * Returns the digest of the this version or null if it's not known.
+     * Returns the digest of this inventory or null if it's not known.
      *
-     * @return the digest of this version or null
+     * @return the digest of this inventory or null
      */
     @JsonIgnore
-    public String getCurrentDigest() {
-        return currentDigest;
+    public String getInventoryDigest() {
+        return inventoryDigest;
     }
 
     /**
@@ -581,7 +581,7 @@ public class Inventory {
                 ", mutableHead=" + mutableHead +
                 ", objectRootPath='" + objectRootPath + '\'' +
                 ", previousDigest='" + previousDigest + '\'' +
-                ", currentDigest='" + currentDigest + '\'' +
+                ", inventoryDigest='" + inventoryDigest + '\'' +
                 '}';
     }
 
@@ -602,7 +602,7 @@ public class Inventory {
                 Objects.equals(revisionNum, inventory.revisionNum) &&
                 objectRootPath.equals(inventory.objectRootPath) &&
                 Objects.equals(previousDigest, inventory.previousDigest) &&
-                Objects.equals(currentDigest, inventory.currentDigest);
+                Objects.equals(inventoryDigest, inventory.inventoryDigest);
     }
 
     @Override
@@ -611,7 +611,7 @@ public class Inventory {
                 head, contentDirectory, fixityBiMap,
                 manifestBiMap, versions, revisionNum,
                 mutableHead, objectRootPath, previousDigest,
-                currentDigest);
+                inventoryDigest);
     }
 
     /**
@@ -632,7 +632,7 @@ public class Inventory {
         RevisionNum revisionNum;
         String objectRootPath;
         String previousDigest;
-        String currentDigest;
+        String inventoryDigest;
 
         public void withId(String id) {
             this.id = id;
@@ -681,9 +681,9 @@ public class Inventory {
             this.objectRootPath = objectRootPath;
         }
 
-        @JacksonInject("currentDigest")
-        public void withCurrentDigest(String currentDigest) {
-            this.currentDigest = currentDigest;
+        @JacksonInject("inventoryDigest")
+        public void withInventoryDigest(String inventoryDigest) {
+            this.inventoryDigest = inventoryDigest;
         }
 
         public Inventory build() {
@@ -691,7 +691,7 @@ public class Inventory {
                     head, contentDirectory, fixity,
                     manifest, versions, mutableHead,
                     revisionNum, objectRootPath, previousDigest,
-                    currentDigest);
+                    inventoryDigest);
         }
 
     }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/model/InventoryBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/model/InventoryBuilder.java
@@ -60,7 +60,7 @@ public class InventoryBuilder {
     private VersionNum nextHeadVersion;
 
     private String previousDigest;
-    private String currentDigest;
+    private String inventoryDigest;
 
     public InventoryBuilder() {
         fixity = new HashMap<>();
@@ -89,7 +89,7 @@ public class InventoryBuilder {
         this.manifest = PathBiMap.fromFileIdMap(original.getManifest());
         this.versions = new HashMap<>(original.getVersions());
         this.previousDigest = original.getPreviousDigest();
-        this.currentDigest = original.getCurrentDigest();
+        this.inventoryDigest = original.getInventoryDigest();
 
         this.nextHeadVersion = head.nextVersionNum();
     }
@@ -305,8 +305,8 @@ public class InventoryBuilder {
         return this;
     }
 
-    public InventoryBuilder currentDigest(String currentDigest) {
-        this.currentDigest = currentDigest;
+    public InventoryBuilder inventoryDigest(String inventoryDigest) {
+        this.inventoryDigest = inventoryDigest;
         return this;
     }
 
@@ -318,7 +318,7 @@ public class InventoryBuilder {
                 head, contentDirectory, fixityFromBiMap(),
                 manifest.getFileIdToPaths(), versions, mutableHead,
                 revisionNum, objectRootPath, previousDigest,
-                currentDigest);
+                inventoryDigest);
     }
 
     /**

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/ObjectProperties.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/ObjectProperties.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 University of Wisconsin Board of Regents
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.wisc.library.ocfl.core.storage;
+
+import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
+import edu.wisc.library.ocfl.api.model.OcflVersion;
+
+public class ObjectProperties {
+
+    private OcflVersion ocflVersion;
+    private DigestAlgorithm digestAlgorithm;
+    private boolean extensions;
+
+    public ObjectProperties() {
+    }
+
+    public ObjectProperties(OcflVersion ocflVersion,
+                            DigestAlgorithm digestAlgorithm,
+                            boolean extensions) {
+        this.ocflVersion = ocflVersion;
+        this.digestAlgorithm = digestAlgorithm;
+        this.extensions = extensions;
+    }
+
+    /**
+     * @return the OCFL version the object conforms to; may be null
+     */
+    public OcflVersion getOcflVersion() {
+        return ocflVersion;
+    }
+
+    public void setOcflVersion(OcflVersion ocflVersion) {
+        this.ocflVersion = ocflVersion;
+    }
+
+    /**
+     * @return the digest algorithm used in the object's sidecar; may be null
+     */
+    public DigestAlgorithm getDigestAlgorithm() {
+        return digestAlgorithm;
+    }
+
+    public void setDigestAlgorithm(DigestAlgorithm digestAlgorithm) {
+        this.digestAlgorithm = digestAlgorithm;
+    }
+
+    /**
+     * @return true if the object has an extensions directory
+     */
+    public boolean hasExtensions() {
+        return extensions;
+    }
+
+    public void setExtensions(boolean extensions) {
+        this.extensions = extensions;
+    }
+
+    @Override
+    public String toString() {
+        return "ObjectProperties{" +
+                "ocflVersion=" + ocflVersion +
+                ", digestAlgorithm=" + digestAlgorithm +
+                ", extensions=" + extensions +
+                '}';
+    }
+}

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudOcflStorageBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudOcflStorageBuilder.java
@@ -37,9 +37,11 @@ public class CloudOcflStorageBuilder {
     private ObjectMapper objectMapper;
     private CloudClient cloudClient;
     private CloudOcflStorageInitializer initializer;
+    private boolean verifyInventoryDigest;
 
     public CloudOcflStorageBuilder() {
         objectMapper = ObjectMappers.prettyPrintMapper();
+        this.verifyInventoryDigest = true;
     }
 
     /**
@@ -76,6 +78,18 @@ public class CloudOcflStorageBuilder {
     }
 
     /**
+     * Configures whether inventory digests should be verified on read. This means computing the digest of the inventory
+     * file and comparing it with the digest in the inventory's sidecar. Default: true.
+     *
+     * @param verifyInventoryDigest true if inventory digests should be verified on read
+     * @return builder
+     */
+    public CloudOcflStorageBuilder verifyInventoryDigest(boolean verifyInventoryDigest) {
+        this.verifyInventoryDigest = verifyInventoryDigest;
+        return this;
+    }
+
+    /**
      * @return a new {@link CloudOcflStorage} object
      */
     public CloudOcflStorage build() {
@@ -84,7 +98,7 @@ public class CloudOcflStorageBuilder {
             init = new CloudOcflStorageInitializer(cloudClient, objectMapper);
         }
 
-        return new CloudOcflStorage(cloudClient, init);
+        return new CloudOcflStorage(cloudClient, verifyInventoryDigest, init);
     }
 
 }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudOcflStorageInitializer.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/cloud/CloudOcflStorageInitializer.java
@@ -119,7 +119,7 @@ public class CloudOcflStorageInitializer {
         for (var file : listRootObjects()) {
             var path = file.getPath();
             if (path.startsWith("0=")) {
-                existingOcflVersion = OcflVersion.fromOcflVersionString(path.substring(2));
+                existingOcflVersion = OcflVersion.fromOcflVersionFilename(path);
                 break;
             }
         }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageBuilder.java
@@ -26,6 +26,7 @@ package edu.wisc.library.ocfl.core.storage.filesystem;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.wisc.library.ocfl.api.util.Enforce;
+import edu.wisc.library.ocfl.core.storage.cloud.CloudOcflStorageBuilder;
 import edu.wisc.library.ocfl.core.util.ObjectMappers;
 
 import java.nio.file.Path;
@@ -39,10 +40,11 @@ public class FileSystemOcflStorageBuilder {
     private Path repositoryRoot;
     private ObjectMapper objectMapper;
     private FileSystemOcflStorageInitializer initializer;
+    private boolean verifyInventoryDigest;
 
     public FileSystemOcflStorageBuilder() {
         objectMapper = ObjectMappers.prettyPrintMapper();
-
+        verifyInventoryDigest = true;
     }
 
     /**
@@ -79,6 +81,18 @@ public class FileSystemOcflStorageBuilder {
     }
 
     /**
+     * Configures whether inventory digests should be verified on read. This means computing the digest of the inventory
+     * file and comparing it with the digest in the inventory's sidecar. Default: true.
+     *
+     * @param verifyInventoryDigest true if inventory digests should be verified on read
+     * @return builder
+     */
+    public FileSystemOcflStorageBuilder verifyInventoryDigest(boolean verifyInventoryDigest) {
+        this.verifyInventoryDigest = verifyInventoryDigest;
+        return this;
+    }
+
+    /**
      * Builds a new FileSystemOcflStorage object
      *
      * @return file system storage
@@ -89,7 +103,7 @@ public class FileSystemOcflStorageBuilder {
             init = new FileSystemOcflStorageInitializer(objectMapper);
         }
 
-        return new FileSystemOcflStorage(repositoryRoot, init);
+        return new FileSystemOcflStorage(repositoryRoot, verifyInventoryDigest, init);
     }
 
 }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageBuilder.java
@@ -26,7 +26,6 @@ package edu.wisc.library.ocfl.core.storage.filesystem;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.wisc.library.ocfl.api.util.Enforce;
-import edu.wisc.library.ocfl.core.storage.cloud.CloudOcflStorageBuilder;
 import edu.wisc.library.ocfl.core.util.ObjectMappers;
 
 import java.nio.file.Path;

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageBuilder.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageBuilder.java
@@ -37,12 +37,10 @@ import java.nio.file.Path;
 public class FileSystemOcflStorageBuilder {
 
     private Path repositoryRoot;
-    private boolean checkNewVersionFixity;
     private ObjectMapper objectMapper;
     private FileSystemOcflStorageInitializer initializer;
 
     public FileSystemOcflStorageBuilder() {
-        checkNewVersionFixity = false;
         objectMapper = ObjectMappers.prettyPrintMapper();
 
     }
@@ -70,19 +68,6 @@ public class FileSystemOcflStorageBuilder {
     }
 
     /**
-     * Overrides whether the fixity of new version content should be checked on version creation after moving the version
-     * into the OCFL object root. Unless the work directory is on a different volume, it is unlikely that this check
-     * is needed. Default: false
-     *
-     * @param checkNewVersionFixity whether to check fixity on version creation. Default: false
-     * @return builder
-     */
-    public FileSystemOcflStorageBuilder checkNewVersionFixity(boolean checkNewVersionFixity) {
-        this.checkNewVersionFixity = checkNewVersionFixity;
-        return this;
-    }
-
-    /**
      * Overrides the default {@link FileSystemOcflStorageInitializer}. Normally, this does not need to be set.
      *
      * @param initializer the initializer
@@ -104,7 +89,7 @@ public class FileSystemOcflStorageBuilder {
             init = new FileSystemOcflStorageInitializer(objectMapper);
         }
 
-        return new FileSystemOcflStorage(repositoryRoot, checkNewVersionFixity, init);
+        return new FileSystemOcflStorage(repositoryRoot, init);
     }
 
 }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/DigestUtil.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/DigestUtil.java
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
 
 public final class DigestUtil {
 
@@ -43,16 +44,27 @@ public final class DigestUtil {
     }
 
     public static String computeDigestHex(DigestAlgorithm algorithm, Path path) {
-        return computeDigestHex(algorithm, path, false);
+        return computeDigestHex(algorithm.getMessageDigest(), path);
+    }
+
+    public static String computeDigestHex(MessageDigest digest, Path path) {
+        return computeDigestHex(digest, path, false);
     }
 
     public static String computeDigestHex(DigestAlgorithm algorithm, Path path, boolean upperCase) {
-        return Bytes.wrap(computeDigest(algorithm, path)).encodeHex(upperCase);
+        return computeDigestHex(algorithm.getMessageDigest(), path, upperCase);
+    }
+
+    public static String computeDigestHex(MessageDigest digest, Path path, boolean upperCase) {
+        return Bytes.wrap(computeDigest(digest, path)).encodeHex(upperCase);
     }
 
     public static byte[] computeDigest(DigestAlgorithm algorithm, Path path) {
+        return computeDigest(algorithm.getMessageDigest(), path);
+    }
+
+    public static byte[] computeDigest(MessageDigest digest, Path path) {
         try (var channel = FileChannel.open(path, StandardOpenOption.READ)) {
-            var digest = algorithm.getMessageDigest();
             var buffer = ByteBuffer.allocateDirect(BUFFER_SIZE);
 
             while (channel.read(buffer) > -1) {

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
@@ -178,7 +178,9 @@ public final class FileUtil {
 
     public static void copyFileMakeParents(Path src, Path dst, StandardCopyOption... copyOptions) {
         try {
-            Files.createDirectories(dst.getParent());
+            if (Files.notExists(dst.getParent())) {
+                Files.createDirectories(dst.getParent());
+            }
             Files.copy(src, dst, copyOptions);
         } catch (IOException e) {
             throw new OcflIOException(e);
@@ -187,7 +189,9 @@ public final class FileUtil {
 
     public static void moveFileMakeParents(Path src, Path dst, StandardCopyOption... copyOptions) {
         try {
-            Files.createDirectories(dst.getParent());
+            if (Files.notExists(dst.getParent())) {
+                Files.createDirectories(dst.getParent());
+            }
             Files.move(src, dst, copyOptions);
         } catch (IOException e) {
             throw new OcflIOException(e);
@@ -259,6 +263,19 @@ public final class FileUtil {
             } catch (IOException e) {
                 LOG.warn("Failed to delete directory: {}", path, e);
             }
+        }
+    }
+
+    /**
+     * Non-recursive path delete. Any exception is swallowed and logged.
+     *
+     * @param path the path to delete
+     */
+    public static void safeDelete(Path path) {
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            LOG.warn("Failed to delete path: {}", path, e);
         }
     }
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/MultiDigestInputStream.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/MultiDigestInputStream.java
@@ -22,7 +22,7 @@
  * THE SOFTWARE.
  */
 
-package edu.wisc.library.ocfl.core.validation;
+package edu.wisc.library.ocfl.core.util;
 
 import at.favre.lib.bytes.Bytes;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
@@ -38,7 +38,7 @@ import java.util.Map;
 /**
  * Input stream that is able to calculate multiple digests concurrently
  */
-class MultiDigestInputStream extends FilterInputStream {
+public class MultiDigestInputStream extends FilterInputStream {
 
     private final Map<DigestAlgorithm, DigestInputStream> streamMap;
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/UncheckedFiles.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/UncheckedFiles.java
@@ -45,7 +45,7 @@ public final class UncheckedFiles {
         try {
             return Files.createDirectories(path);
         } catch (IOException e) {
-            throw new OcflIOException(e);
+            throw OcflIOException.from(e);
         }
     }
 
@@ -53,7 +53,7 @@ public final class UncheckedFiles {
         try {
             return Files.createDirectory(path);
         } catch (IOException e) {
-            throw new OcflIOException(e);
+            throw OcflIOException.from(e);
         }
     }
 
@@ -61,7 +61,7 @@ public final class UncheckedFiles {
         try {
             Files.copy(src, dst, copyOptions);
         } catch (IOException e) {
-            throw new OcflIOException(e);
+            throw OcflIOException.from(e);
         }
     }
 
@@ -69,7 +69,7 @@ public final class UncheckedFiles {
         try {
             Files.copy(input, dst, copyOptions);
         } catch (IOException e) {
-            throw new OcflIOException(e);
+            throw OcflIOException.from(e);
         }
     }
 
@@ -77,7 +77,7 @@ public final class UncheckedFiles {
         try {
             Files.delete(path);
         } catch (IOException e) {
-            throw new OcflIOException(e);
+            throw OcflIOException.from(e);
         }
     }
 
@@ -85,7 +85,7 @@ public final class UncheckedFiles {
         try {
             return Files.size(path);
         } catch (IOException e) {
-            throw new OcflIOException(e);
+            throw OcflIOException.from(e);
         }
     }
 

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/validation/Validator.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/validation/Validator.java
@@ -41,6 +41,7 @@ import edu.wisc.library.ocfl.core.extension.storage.layout.FlatLayoutExtension;
 import edu.wisc.library.ocfl.core.extension.storage.layout.HashedNTupleIdEncapsulationLayoutExtension;
 import edu.wisc.library.ocfl.core.extension.storage.layout.HashedNTupleLayoutExtension;
 import edu.wisc.library.ocfl.core.util.FileUtil;
+import edu.wisc.library.ocfl.core.util.MultiDigestInputStream;
 import edu.wisc.library.ocfl.core.validation.model.SimpleInventory;
 import edu.wisc.library.ocfl.core.validation.model.SimpleVersion;
 import edu.wisc.library.ocfl.core.validation.storage.FileSystemStorage;
@@ -65,16 +66,14 @@ import java.util.TreeMap;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static edu.wisc.library.ocfl.api.OcflConstants.VALID_INVENTORY_ALGORITHMS;
+
 /**
  * Validates an object directory against the OCFL 1.0 spec
  */
 public class Validator {
 
     private static final Logger LOG = LoggerFactory.getLogger(Validator.class);
-
-    private static final DigestAlgorithm[] POSSIBLE_INV_ALGORITHMS = new DigestAlgorithm[]{
-            DigestAlgorithm.sha256, DigestAlgorithm.sha512
-    };
 
     private static final String OBJECT_NAMASTE_CONTENTS = OcflVersion.OCFL_1_0.getOcflObjectVersion() + "\n";
 
@@ -147,7 +146,7 @@ public class Validator {
         var inventoryPath = ObjectPaths.inventoryPath(objectRootPath);
 
         if (storage.fileExists(inventoryPath)) {
-            var parseResult = parseInventory(inventoryPath, results, POSSIBLE_INV_ALGORITHMS);
+            var parseResult = parseInventory(inventoryPath, results, VALID_INVENTORY_ALGORITHMS);
             parseResult.inventory.ifPresent(inventory ->
                     validateObjectWithInventory(objectRootPath, inventoryPath, inventory,
                             parseResult.digests, parseResult.isValid, contentFixityCheck, results));
@@ -173,7 +172,7 @@ public class Validator {
         }
 
         var results = new ValidationResultsBuilder();
-        var parseResults = parseInventory(inventoryPath, results, POSSIBLE_INV_ALGORITHMS);
+        var parseResults = parseInventory(inventoryPath, results, VALID_INVENTORY_ALGORITHMS);
 
         parseResults.inventory.ifPresent(inventory -> {
             var validationResults = inventoryValidator.validateInventory(inventory, inventoryPath);
@@ -247,7 +246,7 @@ public class Validator {
         if (storage.fileExists(inventoryPath)) {
             ignoreFiles.add(OcflConstants.INVENTORY_FILE);
 
-            var parseResult = parseInventory(inventoryPath, results, POSSIBLE_INV_ALGORITHMS);
+            var parseResult = parseInventory(inventoryPath, results, VALID_INVENTORY_ALGORITHMS);
             parseResult.inventory.ifPresent(inventory -> {
                 var validationResults = inventoryValidator.validateInventory(inventory, inventoryPath);
                 results.addAll(validationResults);

--- a/ocfl-java-core/src/test/java/edu/wisc/library/ocfl/core/inventory/InventoryMapperTest.java
+++ b/ocfl-java-core/src/test/java/edu/wisc/library/ocfl/core/inventory/InventoryMapperTest.java
@@ -1,5 +1,6 @@
 package edu.wisc.library.ocfl.core.inventory;
 
+import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
 import edu.wisc.library.ocfl.core.model.Inventory;
 import edu.wisc.library.ocfl.core.model.RevisionNum;
 import edu.wisc.library.ocfl.core.test.ITestHelper;
@@ -31,29 +32,29 @@ public class InventoryMapperTest {
     public void shouldRoundTripInventory() throws IOException {
         var original = readFile("simple-inventory.json");
         var objectRoot = "path/to/obj1";
-        var digest = "abc123";
-        var inventory = mapper.read(objectRoot, digest, new ByteArrayInputStream(original.getBytes()));
+        var digest = "bd9b8dff3b9b3debe2f5f88023f85bb501603711861b7e3da093fc970e149a0972797b3e03080e43a75974b51420b269dc87cd7bd64836f676ef06844b2ef345";
+        var inventory = mapper.read(objectRoot, DigestAlgorithm.sha512, new ByteArrayInputStream(original.getBytes()));
         assertFalse(inventory.hasMutableHead());
         assertNull(inventory.getRevisionNum());
         var output = writeInventoryToString(inventory);
         assertEquals(original, output);
         assertEquals(objectRoot, inventory.getObjectRootPath());
-        assertEquals(digest, inventory.getCurrentDigest());
+        assertEquals(digest, inventory.getInventoryDigest());
     }
 
     @Test
     public void shouldRoundTripMutableHeadInventory() throws IOException {
         var original = readFile("simple-inventory.json");
         var objectRoot = "path/to/obj2";
-        var digest = "def456";
+        var digest = "bd9b8dff3b9b3debe2f5f88023f85bb501603711861b7e3da093fc970e149a0972797b3e03080e43a75974b51420b269dc87cd7bd64836f676ef06844b2ef345";
         var revision = RevisionNum.fromString("r2");
-        var inventory = mapper.readMutableHead(objectRoot, digest, revision, new ByteArrayInputStream(original.getBytes()));
+        var inventory = mapper.readMutableHead(objectRoot, revision, DigestAlgorithm.sha512, new ByteArrayInputStream(original.getBytes()));
         assertTrue(inventory.hasMutableHead());
         assertEquals(revision, inventory.getRevisionNum());
         var output = writeInventoryToString(inventory);
         assertEquals(original, output);
         assertEquals(objectRoot, inventory.getObjectRootPath());
-        assertEquals(digest, inventory.getCurrentDigest());
+        assertEquals(digest, inventory.getInventoryDigest());
     }
 
     private String readFile(String name) throws IOException {
@@ -63,7 +64,7 @@ public class InventoryMapperTest {
     private String writeInventoryToString(Inventory inventory) {
         var outputStream = new ByteArrayOutputStream();
         mapper.write(outputStream, inventory);
-        return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        return outputStream.toString(StandardCharsets.UTF_8);
     }
 
 }

--- a/ocfl-java-core/src/test/java/edu/wisc/library/ocfl/core/inventory/SidecarMapperTest.java
+++ b/ocfl-java-core/src/test/java/edu/wisc/library/ocfl/core/inventory/SidecarMapperTest.java
@@ -46,41 +46,41 @@ public class SidecarMapperTest {
     @Test
     public void parseSidecarWithSingleSpace() {
         var expected = "abc123";
-        var actual = SidecarMapper.readDigest(writeFile(expected + " "));
+        var actual = SidecarMapper.readDigestRequired(writeFile(expected + " "));
         assertEquals(expected, actual);
     }
 
     @Test
     public void parseSidecarWithMultipleSpace() {
         var expected = "abc123";
-        var actual = SidecarMapper.readDigest(writeFile(expected + "   "));
+        var actual = SidecarMapper.readDigestRequired(writeFile(expected + "   "));
         assertEquals(expected, actual);
     }
     @Test
     public void parseSidecarWithSinglTab() {
         var expected = "abc123";
-        var actual = SidecarMapper.readDigest(writeFile(expected + "\t"));
+        var actual = SidecarMapper.readDigestRequired(writeFile(expected + "\t"));
         assertEquals(expected, actual);
     }
 
     @Test
     public void parseSidecarWithMultipleTabs() {
         var expected = "abc123";
-        var actual = SidecarMapper.readDigest(writeFile(expected + "\t\t"));
+        var actual = SidecarMapper.readDigestRequired(writeFile(expected + "\t\t"));
         assertEquals(expected, actual);
     }
 
     @Test
     public void failWhenSinglePart() {
         assertThrows(CorruptObjectException.class, () -> {
-            SidecarMapper.readDigest(writeFile("blah"));
+            SidecarMapper.readDigestRequired(writeFile("blah"));
         });
     }
 
     @Test
     public void failWhenTooManyParts() {
         assertThrows(CorruptObjectException.class, () -> {
-            SidecarMapper.readDigest(writeFile("blah blah blah "));
+            SidecarMapper.readDigestRequired(writeFile("blah blah blah "));
         });
     }
 

--- a/ocfl-java-core/src/test/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageTest.java
+++ b/ocfl-java-core/src/test/java/edu/wisc/library/ocfl/core/storage/filesystem/FileSystemOcflStorageTest.java
@@ -1,8 +1,6 @@
 package edu.wisc.library.ocfl.core.storage.filesystem;
 
 import edu.wisc.library.ocfl.api.OcflConstants;
-import edu.wisc.library.ocfl.api.exception.CorruptObjectException;
-import edu.wisc.library.ocfl.api.exception.FixityCheckException;
 import edu.wisc.library.ocfl.api.exception.NotFoundException;
 import edu.wisc.library.ocfl.api.exception.OcflStateException;
 import edu.wisc.library.ocfl.api.model.DigestAlgorithm;
@@ -32,7 +30,6 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/BadReposITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/BadReposITest.java
@@ -97,7 +97,7 @@ public abstract class BadReposITest {
         var repoName = "missing-sidecar";
         var repo = defaultRepo(repoName);
         assertThat(assertThrows(CorruptObjectException.class, () -> repo.describeObject("o2")).getMessage(),
-                containsString("inventory sidecar"));
+                containsString("sidecar"));
     }
 
     @Test

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/OcflITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/OcflITest.java
@@ -87,7 +87,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class OcflITest {
 

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/filesystem/FileSystemBadReposITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/filesystem/FileSystemBadReposITest.java
@@ -15,7 +15,6 @@ public class FileSystemBadReposITest extends BadReposITest {
                 .inventoryCache(new NoOpCache<>())
                 .inventoryMapper(ITestHelper.testInventoryMapper())
                 .fileSystemStorage(storage -> storage
-                        .checkNewVersionFixity(true)
                         .objectMapper(ITestHelper.prettyPrintMapper())
                         .repositoryRoot(repoDir(name))
                         .build())

--- a/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/filesystem/FileSystemMutableHeadITest.java
+++ b/ocfl-java-itest/src/test/java/edu/wisc/library/ocfl/itest/filesystem/FileSystemMutableHeadITest.java
@@ -40,7 +40,6 @@ public class FileSystemMutableHeadITest extends MutableHeadITest {
                 .inventoryCache(new NoOpCache<>())
                 .inventoryMapper(ITestHelper.testInventoryMapper())
                 .fileSystemStorage(storage -> storage
-                        .checkNewVersionFixity(true)
                         .objectMapper(ITestHelper.prettyPrintMapper())
                         .repositoryRoot(repoDir)
                         .build())


### PR DESCRIPTION
1. Added `verifyStaging` configuration option, which controls whether the contents of a newly constructed version are verified immediately prior to moving the version into the object. Default: `true`
2. Added `verifyInventoryDigest` configuration option, which controls whether inventory digests are verified on read. Default: `true`
3. Removed `checkNewVersionFixity` configuration option. This option was disabled by default and controlled whether or not staged content files had their digests checked immediately prior to moving them into the object. This check was completely removed.
4. Removed unneeded file existence checks
5. `DefaultOcflObjectUpdater.writeFile()` now streams the file directly the its staging location rather than a temp location first
6. Updating objects by copying files now computes the digest of the files while copying into staging and then deletes the file after the copy if it's a dup, rather than computing the digest first and then deciding whether to copy.
7. Streamlined the S3 logic, reducing the number of list operations, particularly when reading an inventory.