### PR TITLE
fix bug that left empty directories in new versions

### DIFF
--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultOcflObjectUpdater.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/DefaultOcflObjectUpdater.java
@@ -140,6 +140,7 @@ public class DefaultOcflObjectUpdater implements OcflObjectUpdater {
                 ((FixityCheckInputStream) input).checkFixity();
             } catch (FixityCheckException e) {
                 FileUtil.safeDelete(stagingFullPath);
+                FileUtil.deleteDirAndParentsIfEmpty(stagingFullPath.getParent(), stagingDir);
                 throw e;
             }
         }
@@ -157,6 +158,7 @@ public class DefaultOcflObjectUpdater implements OcflObjectUpdater {
         if (!result.isNew()) {
             LOG.debug("Deleting file <{}> because a file with same digest <{}> is already present in the object", stagingFullPath, digest);
             UncheckedFiles.delete(stagingFullPath);
+            FileUtil.deleteDirAndParentsIfEmpty(stagingFullPath.getParent(), stagingDir);
         } else {
             stagedFileMap.put(destinationPath, stagingFullPath);
         }

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/AddFileProcessor.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/inventory/AddFileProcessor.java
@@ -152,6 +152,7 @@ public class AddFileProcessor {
                         } else {
                             LOG.debug("Deleting file <{}> because a file with same digest <{}> is already present in the object", stagingFullPath, digest);
                             Files.delete(stagingFullPath);
+                            FileUtil.deleteDirAndParentsIfEmpty(stagingFullPath.getParent(), stagingDir);
                         }
                     } catch (IOException e) {
                         throw new OcflIOException(e);

--- a/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
+++ b/ocfl-java-core/src/main/java/edu/wisc/library/ocfl/core/util/FileUtil.java
@@ -244,6 +244,23 @@ public final class FileUtil {
     }
 
     /**
+     * Deletes the specified path and all of its ancestors until the stop directory is reached
+     *
+     * @param path directory to delete
+     * @param stop directory to stop at
+     */
+    public static void deleteDirAndParentsIfEmpty(Path path, Path stop) {
+        if (path.equals(stop)) {
+            return;
+        }
+
+        if (FileUtil.isDirEmpty(path)) {
+            UncheckedFiles.deleteIfExists(path);
+            deleteDirAndParentsIfEmpty(path.getParent(), stop);
+        }
+    }
+
+    /**
      * Deletes the path and all of its children. Any exception that is thrown is logged as a warning.
      *
      * @param path the path to delete


### PR DESCRIPTION
There was a bug introduced in v1.3.0 where duplicate files either copied or streamed into nested paths would leave empty directories in the version content. For example, writing `a/b/file.txt`, where `file.txt` is a duplicate of a file already in the object, would result in the empty directories `a/b` being left in the version.

This PR fixes the problem.